### PR TITLE
Installation Data

### DIFF
--- a/implementing_installation.md
+++ b/implementing_installation.md
@@ -1,0 +1,27 @@
+# Implementing Installation Information
+
+This document exists as a guide for launchers and other automation tools that may work with installation information. This is not a comprehensive manual and it may not fit for every launcher. However, it's recommended to follow this guide as accurately as possible in order to have a smooth experience.
+
+## Implementing `placeInDirectory`
+
+The `directory` field in this value should be relative to Minecraft installation that the project is being installed to. This field is subject to path rules defined in **installation.md - Specifying Paths**. Launchers should check for rule violations in any field where a directory is passed in order to ensure format-compliant information.
+
+Files should be placed with the same filename and file extension as when downloaded.
+
+## Implementing `versionJsonInstall`
+
+Launchers will likely already have the mechanisms in place to parse Minecraft version JSON files. To install a Version with the `versionJsonInstall` method, first find a file with the `rel` value set to `versionJson`. If a file is not present, an error should be presented to the user. If multiple files are found, the first one should be used.
+
+Launchers can then use the file with the `versionJson` relation and automatically install libraries from URLs specified in the JSON file.
+
+## Implementing `runInstaller`
+
+This is a very vague method and there's no correct way to implement it. Launchers can run the file marked with the platform's current installer, `installer-(win, macos, or linux)`, or `generic-installer` if a platform-native one is not specified.
+
+Implementation of `runInstaller` mostly lies on the launcher. Launchers may add special exemptions for certain modloaders, for example.
+
+## Implementing `other`
+
+If an `other` installation method is found, an error should be presented to the user.
+
+`TODO: Add implementing jar mods`

--- a/implementing_installation.md
+++ b/implementing_installation.md
@@ -14,6 +14,10 @@ Launchers will likely already have the mechanisms in place to parse Minecraft ve
 
 Launchers can then use the file with the `versionJson` relation and automatically install libraries from URLs specified in the JSON file.
 
+## Implementing `classpathLibrary`
+
+This is a library that needs to be on the Minecraft classpath. Launchers can choose to place the file marked with `primary` anywhere. An optional `versionJson` field describes how the classpath would be specified in a version JSON file.
+
 ## Implementing `runInstaller`
 
 This is a very vague method and there's no correct way to implement it. Launchers can run the file marked with the platform's current installer, `installer-(win, macos, or linux)`, or `generic-installer` if a platform-native one is not specified.
@@ -28,8 +32,10 @@ Launchers should follow these steps in order to correctly install these projects
 - Install the required dependencies to the directory according to their installation info
 - If a file with `"rel": "compressedOverrides"` exists, download it and extract the contents to the instance directory
 
+## Implementing `jarMod`
+
+The File marked with `primary` should be downloaded to a temporary location. The file should then be extracted. The contents of this file should be copied over to the Minecraft Game JAR (also extracted). Launchers may choose to automatically delete META-INF.
+
 ## Implementing `other`
 
 If an `other` installation method is found, an error should be presented to the user.
-
-`TODO: Add implementing jar mods`

--- a/implementing_installation.md
+++ b/implementing_installation.md
@@ -20,6 +20,14 @@ This is a very vague method and there's no correct way to implement it. Launcher
 
 Implementation of `runInstaller` mostly lies on the launcher. Launchers may add special exemptions for certain modloaders, for example.
 
+## Implementing `instanceInstall`
+
+Launchers should follow these steps in order to correctly install these projects:
+
+- Create a new directory specifically for this instance.
+- Install the required dependencies to the directory according to their installation info
+- If a file with `"rel": "compressedOverrides"` exists, download it and extract the contents to the instance directory
+
 ## Implementing `other`
 
 If an `other` installation method is found, an error should be presented to the user.

--- a/installation.md
+++ b/installation.md
@@ -39,7 +39,7 @@ This should be installed according to the file with `"rel": "versionJson"`. This
 
 This MUST be used for Versions that contain a file with `"rel": "versionJson"`. If a file with the `versionJson` relation is not present, this method is invalid. It is RECOMMENDED to place this method inside the Version Object instead of a File Object.
 
-## `classpathLibrary`
+### `classpathLibrary`
 
 This project is a library that must be present on the Minecraft classpath.
 
@@ -50,6 +50,15 @@ Launchers should use the value of the `versionJson` field to correlate libraries
 ### `runInstaller`
 
 The file with an installer relation value should be executed. Note that this field is very vague and it's recommended to use something with more information such as `versionJsonInstall`.
+
+### `instanceInstall`
+
+This is a modpack/instance and should be treated as such. Required dependencies should be installed to a directory specific to this instance, then files should be extracted from a file with `"rel" "compressedOverrides"` and moved to the directory.
+
+If this is a modpack, mods should be listed as a required dependency if it is possible to do so.
+
+Files in the `compressedOverrides` zip should be in the root. For example:
+`overrides.zip/overrides/overridden_file.txt` shouldn't be used. Instead, `overrides.zip/overridden_file.txt` is better.
 
 ### `other`
 

--- a/installation.md
+++ b/installation.md
@@ -1,0 +1,17 @@
+# Automating Installation
+
+The ability to automate installation of mods is important. However, there are many complex variables that come with automated installs.
+
+Per my draft spec ([PR viewable here](https://github.com/mc-cip/spec/pull/6)), both Versions and Files can have `installation` objects, which describe how projects can be installed. This separation allows automated installs to require multiple files, while retaining the ability to have separate methods per file.
+
+## Installation Methods
+
+Files and versions can contain the `installation` object, which informs how to install the file. It contains the `method` field, which has the following possible values:
+
+- `placeInDirectory` - Place this file in a specified directory, relative to the path of the Minecraft game. Specify the directory in a field named `directory` installed the `installation` object
+- `jarMod` - This file is a jar mod, and must be added to minecraft.jar
+- `versionJsonInstall` - This version must be installed according to the file with the `versionJson` relation.
+- `runForgeInstaller` - This version should be installed using a Forge installer. Launchers MAY ignore this.
+- `other` - Unknown installation method
+
+For framework values such as `versionJsonInstall` and `runForgeInstaller`, launchers may ignore them if they do not provide enough information or they do not want to implement them. For example, a launcher may not want to run the Forge installer and instead perform the installation themselves.

--- a/installation.md
+++ b/installation.md
@@ -4,14 +4,80 @@ The ability to automate installation of mods is important. However, there are ma
 
 Per my draft spec ([PR viewable here](https://github.com/mc-cip/spec/pull/6)), both Versions and Files can have `installation` objects, which describe how projects can be installed. This separation allows automated installs to require multiple files, while retaining the ability to have separate methods per file.
 
+## A notice about launchers
+
+It's important to remember that launchers may choose to ignore provided information or deviate from the spec. This is true of all formats and standards, but it's especially true for something as complex as installation. If you're providing installation information in the MCIP format, it's important to keep in mind that not all launchers will use data the same way.
+
+## Storing Installation Information
+
+Installation information is stored in the `installation` object, present in either a Version Object or File Object. For more information on the Version and File Objects, please view the [Spec Draft PR](https://github.com/mc-cip/spec/pull/6).
+
+The `installation` object has a very basic structure. By default, it only requires one field, `method`. This describes the method that launchers and other automation tools should use in order to install and properly set up this project. Any extra information is stored in optional fields also stored inside the `installation` object. These fields are specific to the `method` specified.
+
 ## Installation Methods
 
-Files and versions can contain the `installation` object, which informs how to install the file. It contains the `method` field, which has the following possible values:
+The following is a comprehensive summary of every available installation method in the MCIP format. Information on how launchers should implement handling of these methods is described in **implementing_installation.md**.
 
-- `placeInDirectory` - Place this file in a specified directory, relative to the path of the Minecraft game. Specify the directory in a field named `directory` installed the `installation` object
-- `jarMod` - This file is a jar mod, and must be added to minecraft.jar
-- `versionJsonInstall` - This version must be installed according to the file with the `versionJson` relation.
-- `runForgeInstaller` - This version should be installed using a Forge installer. Launchers MAY ignore this.
-- `other` - Unknown installation method
+##### Version Notice
 
-For framework values such as `versionJsonInstall` and `runForgeInstaller`, launchers may ignore them if they do not provide enough information or they do not want to implement them. For example, a launcher may not want to run the Forge installer and instead perform the installation themselves.
+If a method is used in a Version Object instead of a File Object, the default implementation is to apply the installation behavior to allow of the files marked `"rel": "primary"`. If this differs for a method, it will be noted.
+
+### `placeInDirectory`
+
+Place the file in the directory specified in the extra `directory` field.
+
+The `directory` field is subject to the rules defined in **Specifying Paths**.
+
+### `jarMod`
+
+This is a jar mod, and the contents of it must be added to the Minecraft jar file. See the Implementing Installation document. The file specified MUST be in the .zip format.
+`TODO: should other formats be supported?`
+
+### `versionJsonInstall`
+
+This should be installed according to the file with `"rel": "versionJson"`. This should be only used for Projects which NEED a version JSON file, like modloaders.
+
+This MUST be used for Versions that contain a file with `"rel": "versionJson"`. If a file with the `versionJson` relation is not present, this method is invalid. It is RECOMMENDED to place this method inside the Version Object instead of a File Object.
+
+### `runInstaller`
+
+The file with an installer relation value should be executed. Note that this field is very vague and it's recommended to use something with more information such as `versionJsonInstall`.
+
+### `other`
+
+An unknown installation method.
+
+`TODO: what other methods should be added? what about classpath dependencies that are not specified in version.json files?`
+
+---
+
+## Specifying Paths
+
+Some fields, such as `placeInDirectory`'s `directory` field, requires a path to be supplied. This path by default is relative to the root of the Minecraft Instance that this project is being installed to. If the Project is not able to be installed to a Minecraft Instance for whatever reason, it is up to launchers to supply a default relative path.
+
+Paths MUST use forward slashes to indicate nesting. Backslashes (even on Windows systems) CANNOT be used.
+
+Paths MAY start with `./`, however it is not needed. For example, `./mods` is a valid directory path, however `mods` also works and does not have the unnecessary `./`.
+
+Absolute paths MAY be specified by prefixing the path with an absolute path prefix. This prefix has two valid options:
+
+- `/` character for Unix-like systems
+- Windows device prefix path (e.g. `C:/`)
+
+Absolute prefixes are HIGHLY DISCOURAGED and should only be used when absolutely necessary. For example, a mod that installs itself to the `mods` folder SHOULD NOT use an absolute path, and instead should specify `mods`.
+
+The following are rules on paths and filenames:
+
+- Paths that contain Windows restricted filenames and characters are not allowed
+  - Restricted characters are `<`, `>`, `:`, `"`, `|`, `?`, `*`
+- Empty strings are not allowed
+  - If you need to specify the current relative path, without using a subdirectory, use `.`
+- Filenames CANNOT contain a slash or backslash
+- Filenames that end in `.` CANNOT be used
+- Filenames that end in a space CANNOT be used
+- New line and carriage return characters CANNOT be used
+- Most Unicode characters are allowed, but using normal ASCII characters (A-Z, a-z, 0-9) is recommended
+
+  - Restricted Unicode characters include NUL and CR
+
+`TODO: more information on restricted characters`

--- a/installation.md
+++ b/installation.md
@@ -39,6 +39,14 @@ This should be installed according to the file with `"rel": "versionJson"`. This
 
 This MUST be used for Versions that contain a file with `"rel": "versionJson"`. If a file with the `versionJson` relation is not present, this method is invalid. It is RECOMMENDED to place this method inside the Version Object instead of a File Object.
 
+## `classpathLibrary`
+
+This project is a library that must be present on the Minecraft classpath.
+
+This has an optional `versionJson` field. The field is an object and it contains the information that would be stored about the project if it were specified in a version JSON file, such as `name` and `url`.
+
+Launchers should use the value of the `versionJson` field to correlate libraries defined in a version JSON file and a library in MCIP format.
+
 ### `runInstaller`
 
 The file with an installer relation value should be executed. Note that this field is very vague and it's recommended to use something with more information such as `versionJsonInstall`.

--- a/installation.md
+++ b/installation.md
@@ -30,8 +30,7 @@ The `directory` field is subject to the rules defined in **Specifying Paths**.
 
 ### `jarMod`
 
-This is a jar mod, and the contents of it must be added to the Minecraft jar file. See the Implementing Installation document. The file specified MUST be in the .zip format.
-`TODO: should other formats be supported?`
+This is a jar mod, and the contents of it must be added to the Minecraft jar file. See the Implementing Installation document. The file specified MUST be either a .zip or .jar file.
 
 ### `versionJsonInstall`
 
@@ -64,7 +63,7 @@ Files in the `compressedOverrides` zip should be in the root. For example:
 
 An unknown installation method.
 
-`TODO: what other methods should be added? what about classpath dependencies that are not specified in version.json files?`
+`TODO: what other methods should be added?`
 
 ---
 


### PR DESCRIPTION
(moved from #6 as it's more complex than we thought)
This describes how information on how to install projects can be defined in the spec. 